### PR TITLE
Make MAPcore page heroku compatible

### DIFF
--- a/map_core/app/package.json
+++ b/map_core/app/package.json
@@ -20,8 +20,9 @@
   "devDependencies": {
     "mapcoreintegratedwebapp": "^0.0.1alpha",
     "split.js": "^1.5.11",
-    "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "webpack": "^4.29.6"
+  }
 }

--- a/map_core/app/package.json
+++ b/map_core/app/package.json
@@ -19,10 +19,10 @@
   ],
   "devDependencies": {
     "mapcoreintegratedwebapp": "^0.0.1alpha",
-    "split.js": "^1.5.11",
-    "webpack-cli": "^3.2.3"
+    "split.js": "^1.5.11"
   },
   "dependencies": {
-    "webpack": "^4.29.6"
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.2.3"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,4 @@ six==1.12.0
 urllib3==1.24.1
 Werkzeug==0.14.1
 wrapt==1.11.1
--e git://github.com/alan-wu/scaffoldmaker-webapp.git#egg=scaffoldmaker_webapp
+


### PR DESCRIPTION
The scaffoldmaker package on git cannot be found on Heroku, removing it as it is not used currently.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
