### PR TITLE
Now send settings to dialog on initialisation

### DIFF
--- a/map_core/app/src/tabmanager.js
+++ b/map_core/app/src/tabmanager.js
@@ -72,7 +72,7 @@ exports.TabManager = function(parentIn, moduleManagerIn ) {
 		for (let i = 0; i < settings.length; i++) {
 			let setting = settings[i];
 			if (setting.dialog) {
-				let data = _this.createDialog(setting.dialog);
+				let data = _this.createDialog(setting.dialog, setting);
 				data.module.importSettings(setting);
 				_this.setTitle(data, data.module.instanceName);
 			}


### PR DESCRIPTION
Data-viewer now takes a url on initialisation so we really need those settings on initialisation. 

Tested the loading hash settings into other dialogs and they are all loading successfully.

(This fixes hashing not working for Data Viewer)