### PR TITLE
Update fdikbquery to 0.1.15 to use new stellate URI

### DIFF
--- a/map_core/app/package.json
+++ b/map_core/app/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@tehsurfer/chariot-tooltips": "^1.0.7",
     "broadcast-channel": "^2.1.12",
-    "fdikbquery": "^0.1.13",
+    "fdikbquery": "^0.1.15",
     "jquery": "^3.4.1",
     "mapcoreintegratedwebapp": "^0.2.8",
     "webpack": "^4.29.6",


### PR DESCRIPTION
This will allow us to navigate all provided stellate files on data.sparc.science
