### PR TITLE
Widget background colour now matches ui components

### DIFF
--- a/map_core/app/package.json
+++ b/map_core/app/package.json
@@ -28,7 +28,7 @@
     "broadcast-channel": "^2.1.12",
     "fdikbquery": "^0.1.15",
     "jquery": "^3.4.1",
-    "mapcoreintegratedwebapp": "^0.2.8",
+    "mapcoreintegratedwebapp": "^0.2.10",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
   }

--- a/map_core/app/src/css/mapcore.css
+++ b/map_core/app/src/css/mapcore.css
@@ -120,6 +120,10 @@
 	border: none;
 }
 
+.ui-widget-content{
+  background: white;
+}
+
 ui-widget-content {
 	border: none;
 }


### PR DESCRIPTION
This fixes Item 55: Background at times is a different colour to
background of items in mapcore panel.
